### PR TITLE
fix: undefined error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ const cssDiff = (source, reversed) => {
 
   Object.keys(reversedObject).forEach(selector => {
     Object.keys(reversedObject[selector]).forEach(prop => {
-      if (sourceObject[selector][prop]) {
+      if ((sourceObject[selector] || {})[prop]) {
         if (sourceObject[selector][prop] !== reversedObject[selector][prop]) {
           diff = addProp(diff, selector, prop, reversedObject[selector][prop])
         }


### PR DESCRIPTION
When I try to use this tool, I get the error:

```txt
(node:39016) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'font-family' of undefined
    at ~\node_modules\@romainberger\css-diff\lib\index.js:78:33
```

This PR fixes this by making sure the undefined error is not thrown.